### PR TITLE
Mini private key format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-key-tool"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base58",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-key-tool"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base58",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-key-tool"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A tool for interacting with bitcoin keys and addresses"

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,10 @@ struct Args {
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
-    // try from wif, then try from hex
-    let pk = key::parse_wif(&args.private_key).or_else(|_| key::parse_hex(&args.private_key))?;
+    // first try mini private key format, then WIF, then hex
+    let pk = key::parse_mpkf(&args.private_key)
+        .or_else(|_| key::parse_wif(&args.private_key))
+        .or_else(|_| key::parse_hex(&args.private_key))?;
     let pk = pk.compressed(args.compressed).network(args.network);
 
     println!("Private key: {}", hex::encode(pk.private_key_bytes()));


### PR DESCRIPTION
https://en.bitcoin.it/wiki/Mini_private_key_format

we won't be able to go backwards and derive a mini private key format since they're developed via a 1-way brute force algorithm, but we can at least support them the other ways.